### PR TITLE
fix changelog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ If you found a bug, please use the [issue tracker][issue-tracker].
 > https://github.com/pinellolab/perturbvelo
 
 [issue-tracker]: https://github.com/pinellolab/perturbvelo/issues
-[changelog]: https://perturbvelo.readthedocs.io/latest/changelog.html
+[changelog]: https://perturbvelo.readthedocs.io/en/latest/changelog.html
 [link-docs]: https://perturbvelo.readthedocs.io
 [link-api]: https://perturbvelo.readthedocs.io/en/latest/api.html


### PR DESCRIPTION
Should now link properly to the readthedocs changelog page.