### PR TITLE
Fix codecov CI and update template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,23 +1,23 @@
 {
-    "template": "https://github.com/scverse/cookiecutter-scverse",
-    "commit": "57f6267716826dad73baba46dc3c00fe7262c459",
-    "checkout": "v0.2.0",
-    "context": {
-        "cookiecutter": {
-            "project_name": "perturbvelo",
-            "package_name": "perturbvelo",
-            "project_description": "Probabilistic model of RNA metabolism perturbation response",
-            "author_full_name": "Pinello Lab",
-            "author_email": "cameron.ray.smith@gmail.com",
-            "github_user": "pinellolab",
-            "project_repo": "https://github.com/pinellolab/perturbvelo",
-            "license": "GNU General Public License Version 3",
-            "_copy_without_render": [
-                ".github/workflows/**.yaml",
-                "docs/_templates/autosummary/**.rst"
-            ],
-            "_template": "https://github.com/scverse/cookiecutter-scverse"
-        }
-    },
-    "directory": null
+  "template": "https://github.com/scverse/cookiecutter-scverse",
+  "commit": "c21b82bf134f3a0f13db7482d4fb04ca1f562d59",
+  "checkout": "main",
+  "context": {
+    "cookiecutter": {
+      "project_name": "perturbvelo",
+      "package_name": "perturbvelo",
+      "project_description": "Probabilistic model of RNA metabolism perturbation response",
+      "author_full_name": "Pinello Lab",
+      "author_email": "cameron.ray.smith@gmail.com",
+      "github_user": "pinellolab",
+      "project_repo": "https://github.com/pinellolab/perturbvelo",
+      "license": "GNU General Public License Version 3",
+      "_copy_without_render": [
+        ".github/workflows/**.yaml",
+        "docs/_templates/autosummary/**.rst"
+      ],
+      "_template": "https://github.com/scverse/cookiecutter-scverse"
+    }
+  },
+  "directory": null
 }

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,23 +1,23 @@
 {
-  "template": "https://github.com/scverse/cookiecutter-scverse",
-  "commit": "c21b82bf134f3a0f13db7482d4fb04ca1f562d59",
-  "checkout": "main",
-  "context": {
-    "cookiecutter": {
-      "project_name": "perturbvelo",
-      "package_name": "perturbvelo",
-      "project_description": "Probabilistic model of RNA metabolism perturbation response",
-      "author_full_name": "Pinello Lab",
-      "author_email": "cameron.ray.smith@gmail.com",
-      "github_user": "pinellolab",
-      "project_repo": "https://github.com/pinellolab/perturbvelo",
-      "license": "GNU General Public License Version 3",
-      "_copy_without_render": [
-        ".github/workflows/**.yaml",
-        "docs/_templates/autosummary/**.rst"
-      ],
-      "_template": "https://github.com/scverse/cookiecutter-scverse"
-    }
-  },
-  "directory": null
+    "template": "https://github.com/scverse/cookiecutter-scverse",
+    "commit": "c21b82bf134f3a0f13db7482d4fb04ca1f562d59",
+    "checkout": "main",
+    "context": {
+        "cookiecutter": {
+            "project_name": "perturbvelo",
+            "package_name": "perturbvelo",
+            "project_description": "Probabilistic model of RNA metabolism perturbation response",
+            "author_full_name": "Pinello Lab",
+            "author_email": "cameron.ray.smith@gmail.com",
+            "github_user": "pinellolab",
+            "project_repo": "https://github.com/pinellolab/perturbvelo",
+            "license": "GNU General Public License Version 3",
+            "_copy_without_render": [
+                ".github/workflows/**.yaml",
+                "docs/_templates/autosummary/**.rst"
+            ],
+            "_template": "https://github.com/scverse/cookiecutter-scverse"
+        }
+    },
+    "directory": null
 }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,15 +6,21 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     package:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: "3.10"
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
             - name: Install build dependencies
               run: python -m pip install --upgrade pip wheel twine build
             - name: Build package

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -43,4 +43,4 @@ jobs:
                       manually merge these changes.**
 
                       For more information about the template sync, please refer to the
-                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#automated-template-sync).
+                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#automated-template-sync).

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     test:
         runs-on: ${{ matrix.os }}
@@ -24,27 +28,17 @@ jobs:
             PYTHON: ${{ matrix.python }}
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
 
-            - name: Get pip cache dir
-              id: pip-cache-dir
-              run: |
-                  echo "::set-output name=dir::$(pip cache dir)"
-            - name: Restore pip cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.pip-cache-dir.outputs.dir }}
-                  key: pip-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
-                  restore-keys: |
-                      pip-${{ runner.os }}-${{ env.pythonLocation }}-
             - name: Install test dependencies
               run: |
                   python -m pip install --upgrade pip wheel
-                  pip install codecov
             - name: Install dependencies
               run: |
                   pip install ".[dev,test]"
@@ -56,7 +50,4 @@ jobs:
               run: |
                   pytest -v --cov --color=yes
             - name: Upload coverage
-              env:
-                  CODECOV_NAME: ${{ matrix.python }}-${{ matrix.os }}
-              run: |
-                  codecov --required --flags=unittests
+              uses: codecov/codecov-action@v3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,12 +16,15 @@ sys.path.insert(0, str(HERE / "extensions"))
 
 # -- Project information -----------------------------------------------------
 
+# NOTE: If you installed your project in editable mode, this might be stale.
+#       If this is the case, reinstall it to refresh the metadata
 info = metadata("perturbvelo")
 project_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
-repository_url = f"https://github.com/pinellolab/{project_name}"
+urls = dict(pu.split(", ") for pu in info.get_all("Project-URL"))
+repository_url = urls["Source"]
 
 # The full version, including alpha/beta/rc tags
 release = info["Version"]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -142,6 +142,7 @@ Please write documentation for new or changed features and use-cases. This proje
 -   [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
 -   Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
 -   [Sphinx autodoc typehints][], to automatically reference annotated input and output types
+-   Citations (like {cite:p}`Virshup_2023`) can be included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
 
 See the [scanpy developer docs](https://scanpy.readthedocs.io/en/latest/dev/documentation.html) for more information
 on how to write documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,9 @@ ignore = [
     "D213",
 ]
 
+[tool.ruff.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.per-file-ignores]
 "docs/*" = ["I"]
 "tests/*" = ["D"]

--- a/src/perturbvelo/pp/basic.py
+++ b/src/perturbvelo/pp/basic.py
@@ -2,7 +2,7 @@ from anndata import AnnData
 
 
 def basic_preproc(adata: AnnData) -> int:
-    """Run a basic preprocessing on the AnnData :cite:p:`Wolf2018` object.
+    """Run a basic preprocessing on the AnnData object.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR fixes some problems with the CI setup of the scverse-cookiecutter template repo. Last night, [the `codecov` package was pulled from PyPI](https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259). This can easily be replaced, however we've realized our automatic template sync system does not allow us to modify github actions (a security precaution from github), so we need to roll out this update manually.

We're also taking this opportunity to make several other intended changes for to the CI workflow.

We're still looking into how we can avoid this in the future, which will likely require us changing how our template sync system works. This is being tracked in the [scverse/cookiecutter-scverse#138](https://www.github.com/scverse/cookiecutter-scverse/issues/138). 

## Changes

These changes constitute the 0.2.1 release of the template and make the following changes:

* Remove codecov as a dependency since it's been pulled from pypi ([scverse/cookiecutter-scverse#161](https://www.github.com/scverse/cookiecutter-scverse/pull/161))
* Remove usage of deprecated GitHub actions environment variables (these will be removed in a month) ([scverse/cookiecutter-scverse#161](https://www.github.com/scverse/cookiecutter-scverse/pull/161))
* Fix some spurious ruff errors ([scverse/cookiecutter-scverse#156](https://www.github.com/scverse/cookiecutter-scverse/pull/156), [scverse/cookiecutter-scverse#159](https://www.github.com/scverse/cookiecutter-scverse/pull/159))
* Replace the example citation with the scverse manuscript ([scverse/cookiecutter-scverse#160](https://www.github.com/scverse/cookiecutter-scverse/pull/160))
* automatically cancel running CI jobs on new commit ( [scverse/cookiecutter-scverse#158](https://www.github.com/scverse/cookiecutter-scverse/pull/158))

## Additional remarks
* If there are **merge conflicts**, they either show up inline (`>>>>>>>`) or a `.rej` file will have been created for the respective files. You need to address these conflicts manually. Make sure to enable pre-commit.ci (see below) to detect such files.
* The scverse template works best when the [pre-commit.ci](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#pre-commit-ci), [readthedocs](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#documentation-on-readthedocs) and [codecov](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#coverage-tests-with-codecov) services are enabled. Make sure to activate those apps if you haven't already. 
